### PR TITLE
fix mirador app not being unmounted when navigating

### DIFF
--- a/src/components/MiradorViewer.vue
+++ b/src/components/MiradorViewer.vue
@@ -155,6 +155,7 @@ export default {
   beforeDestroy() {
     if (this.resetTimeout)
       clearTimeout(this.resetTimeout)
+    this.viewer.unmount()
   }
 }
 </script>


### PR DESCRIPTION
Mirador generates class names for its components. They are named
mirador1, ..., miradorN.

These classes have associated css rules:
```
.mirador50 {
  display: flex;
}
```

If we unmount our mirador vue component without unmounting the Mirador
app, these css rules are not removed from the DOM.

The render order of the Mirador app's component impacts the naming of
the generated classes, so we can end up in a situation where an element is associated
to both the correct rule and the rule associated with the previous
element which had this class name, leading to bad rendering.

I wasn't able to reproduce locally (probably because the problem happens when there is network latency). But I  manually called `unmount` on the viewer on the `dev.chartes.psl.eu/adele/` site and it seemed to solve the problem :)